### PR TITLE
55 import of v12 has issues with the use for fraction column

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,28 +21,31 @@ The problems we as VMW holders know of are collected [here](problems.md), along 
 
 # Install
 
+To just use the sheet directly from Google, go [here](https://docs.google.com/spreadsheets/d/16urkTZg7GXXgv8mch8PaI9xuXI52F8Lr4K2PWsxK-3w/edit?usp=sharing), `File->Make a copy` then you can start entering data. If you want to use the binary from the repo, instructions are below.
+
 Install is more "import", but there's some fixup required because of a Sheets bug I haven't got a workaround for as yet.
 
 There's [a binary sheet](https://github.com/hickeng/financial/releases/download/v0.1.2/VMW_to_AVGO_ESPP_and_RSU-v0.1.2-github.xlsx) attached to the releases, suitable for import into Google Sheets.
 
 1. Download [the latest sheet](https://github.com/hickeng/financial/releases/download/v0.1.2/VMW_to_AVGO_ESPP_and_RSU-v0.1.2-github.xlsx)
-2. Create a new Google Sheet - [open this in new window](https://docs.google.com/spreadsheets/u/0/create?usp=sheets_home&ths=true)
-3. Go to File->Import->Upload->Browse - this will open a system file selection box. Select the downloaded sheet.
-4. Choose `Replace Spreadsheet`, and select `Import data`
-5. FIXUP: there's a Sheets import bug ([#30](https://github.com/hickeng/financial/issues/30)) that drops the checkbox validation from `Use for fraction` column in ESPP and RSU sheets:
+1. Create a new Google Sheet - [open this in new window](https://docs.google.com/spreadsheets/u/0/create?usp=sheets_home&ths=true)
+1. Go to File->Import->Upload->Browse - this will open a system file selection box. Select the downloaded sheet.
+1. Choose `Replace Spreadsheet`, and select `Import data`
+1. FIXUP: there's a Sheets import bug ([#30](https://github.com/hickeng/financial/issues/30)) that drops the checkbox validation from `Use for fraction` column in ESPP and RSU sheets:
    1. Menu `Data->Data validation`, then `Add rule` at the bottom of the right side pane that opens.
-   2. Set `Apply to range` to `ESPP!N7:N26`, `Criteria` to `Tick box`. Click `Done`.
-   3. Repeat (2) but with `Apply to range` as `RSU!J7:J84`
-   4. If `ESPP!N5` is displaying `#REF!`, replace the cell formula with `=COUNTIF(N7:N26, TRUE)`
-   5. Repeat (4) but for `RSU!J5`, replacing with `=COUNTIF(J7:J84, TRUE)`
-   6. (the bottom sums are just for convenience and because people expect totals at the bottom - fix them up with the same formula if you care)
-5. Import the AppScript (needed for running lot optimization)
+   1. Set `Apply to range` to `ESPP!N7:N26`, `Criteria` to `Tick box`. Click `Done`.
+   1. Repeat (2) but with `Apply to range` as `RSU!J7:J84`
+   1. If `ESPP!N5` is displaying `#REF!`, replace the cell formula with `=COUNTIF(N7:N26, TRUE)`
+   1. Repeat (4) but for `RSU!J5`, replacing with `=COUNTIF(J7:J84, TRUE)`
+   1. (the bottom sums are just for convenience and because people expect totals at the bottom - fix them up with the same formula if you care)
+1. Import the AppScript (needed for running lot optimization)
    1. In the sheet, `Extensions->App Scripts` and copy the .gs files from the repo worksheet directory.
    1. Either reload the spreadsheet, or run the `common.gs:onOpen` function using the AppScript UI
    1. Menu `Custom Functions->All balance` to trigger auth prompts
    1. Accept the authorization prompts - like self-signed website certs, you need to look at the small links below the main warning and text to proceed.
 1. Run the `Custom Functions->Optimize per-lot (avgo basis)` function - you'll be    
    1. This sets the preference for each lot to `cash` or `shares` and you'll see the impact if choosing `manual per-lot ratio` in the Tweaks.
+   1. If you want to make changes to the sheet, then export those changes for a PR, use the `Custom Functions->Export Workbook (Censored)`. This will write json to a Google Drive location and is the mechanism I use to construct the json [in the repo](worksheet/). These are intended for easy visual review of diffs. Well, easy compared to doing it as a spreadsheet.
 
 
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,32 @@ The problems we as VMW holders know of are collected [here](problems.md), along 
 * ... if you know of others, please open an issue or pull request
 
 
+# Install
+
+Install is more "import", but there's some fixup required because of a Sheets bug I haven't got a workaround for as yet.
+
+There's [a binary sheet](https://github.com/hickeng/financial/releases/download/v0.1.2/VMW_to_AVGO_ESPP_and_RSU-v0.1.2-github.xlsx) attached to the releases, suitable for import into Google Sheets.
+
+1. Download [the latest sheet](https://github.com/hickeng/financial/releases/download/v0.1.2/VMW_to_AVGO_ESPP_and_RSU-v0.1.2-github.xlsx)
+2. Create a new Google Sheet - [open this in new window](https://docs.google.com/spreadsheets/u/0/create?usp=sheets_home&ths=true)
+3. Go to File->Import->Upload->Browse - this will open a system file selection box. Select the downloaded sheet.
+4. Choose `Replace Spreadsheet`, and select `Import data`
+5. FIXUP: there's a Sheets import bug ([#30](https://github.com/hickeng/financial/issues/30)) that drops the checkbox validation from `Use for fraction` column in ESPP and RSU sheets:
+   1. Menu `Data->Data validation`, then `Add rule` at the bottom of the right side pane that opens.
+   2. Set `Apply to range` to `ESPP!N7:N26`, `Criteria` to `Tick box`. Click `Done`.
+   3. Repeat (2) but with `Apply to range` as `RSU!J7:J84`
+   4. If `ESPP!N5` is displaying `#REF!`, replace the cell formula with `=COUNTIF(N7:N26, TRUE)`
+   5. Repeat (4) but for `RSU!J5`, replacing with `=COUNTIF(J7:J84, TRUE)`
+   6. (the bottom sums are just for convenience and because people expect totals at the bottom - fix them up with the same formula if you care)
+5. Import the AppScript (needed for running lot optimization)
+   1. In the sheet, `Extensions->App Scripts` and copy the .gs files from the repo worksheet directory.
+   1. Either reload the spreadsheet, or run the `common.gs:onOpen` function using the AppScript UI
+   1. Menu `Custom Functions->All balance` to trigger auth prompts
+   1. Accept the authorization prompts - like self-signed website certs, you need to look at the small links below the main warning and text to proceed.
+1. Run the `Custom Functions->Optimize per-lot (avgo basis)` function - you'll be    
+   1. This sets the preference for each lot to `cash` or `shares` and you'll see the impact if choosing `manual per-lot ratio` in the Tweaks.
+
+
 
 # Release Status
 
@@ -38,19 +64,6 @@ The Tweak is found as a dropdown below the Fractional Share Values and contains 
 * a series of dates on which RSUs transition from STG to LTG
 
 On the same row there is a share price, set to AVGO live by default that you can overwrite with any postive value.
-
-
-There's [a binary sheet](https://github.com/hickeng/financial/releases/download/v0.1.2/VMW_to_AVGO_ESPP_and_RSU-v0.1.2-github.xlsx) attached to the releases, suitable for import into Google Sheets.
-
-1. Download [the sheet](https://github.com/hickeng/financial/releases/download/v0.1.2/VMW_to_AVGO_ESPP_and_RSU-v0.1.2-github.xlsx)
-2. Create a new Google Sheet - [open this in new window](https://docs.google.com/spreadsheets/u/0/create?usp=sheets_home&ths=true)
-3. Go to File->Import->Upload->Browse - this will open a system file selection box. Select the downloaded sheet.
-4. Choose `Replace Spreadsheet`, and select `Import data`
-5. Import the AppScript (needed for running lot optimization)
-   1. In the sheet, `Extensions->App Scripts` and copy the .gs files from the repo worksheet directory. You can just pasted them all into one large file if need be.
-   2. Either reload the spreadsheet, or run the `common.gs:onOpen` function using the AppScript UI
-6. Go to the new sheet menu `Custom Functions->Optimize per-lot selection`
-   1. This should set the preference for each lot to `cash` or `shares` and you'll see the impact if choosing `manual per-lot ratio` in the Tweaks.
 
 
 ## [v0.1.1](https://github.com/hickeng/financial/releases/tag/v0.1.0) - 2024-02-20


### PR DESCRIPTION
Promotes the import instructions from the latest release to its own section.
Adds fixup information to work around #30.
Adds a link to the shared version of the sheet to avoid needing import
Refines the instructions a little, and updates references to menu names for the v0.1.2 release

fixes #55 